### PR TITLE
Fixing a bug in line 223

### DIFF
--- a/John/run/pdf2john.py
+++ b/John/run/pdf2john.py
@@ -220,6 +220,8 @@ class PdfParser:
         return object_id
 
     def get_pdf_object(self, object_id):
+        if isinstance(object_id, str):
+            object_id = object_id.encode()
         output = object_id+b" obj" + \
             self.encrypted.partition(b"\r"+object_id+b" obj")[2]
         if(output == object_id+b" obj"):


### PR DESCRIPTION
The script was crashing due to incorrect str-byte concatenation.  See the snippet below.
```bash
$ python3 pdf2john.py ~/win/Downloads/8527273050231012021.pdf
Traceback (most recent call last):
  File "pdf2john.py", line 329, in <module>
    parser.parse()
  File "pdf2john.py", line 116, in parse
    gecos = self.parse_meta_data(trailer)
  File "pdf2john.py", line 173, in parse_meta_data
    xmp_metadata_object = self.get_pdf_object(object_id)
  File "pdf2john.py", line 223, in get_pdf_object
    print(">>", repr(object_id.decode()))
AttributeError: 'str' object has no attribute 'decode'
```